### PR TITLE
Add field selector and ability to filter by formula

### DIFF
--- a/docs/data-sources/table.md
+++ b/docs/data-sources/table.md
@@ -13,8 +13,10 @@ The `airtable_table` resource allows you to read information from a table for us
 
 ```terraform
 data "airtable_table" "test" {
-	"workspace_id" = "appOYVvt71h5txnFZ"
-	"table"        = "Table 1"
+	workspace_id      = "appOYVvt71h5txnFZ"
+	table             = "Table 1"
+	fields            = ["some_field", "another field", "One more (field)"]
+	filter_by_formula = "AND({another field} > 9000, {One more (field)} != 'over nine thousand!')"
 }
 ```
 
@@ -30,6 +32,8 @@ data "airtable_table" "test" {
 - **id** (String, Optional) The ID of this resource.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - **view** (String, Optional) Name of the view from which to query information.
+- **fields** (List, Optional) Name of the fields (or columns) returned from the table
+- **filter_by_formula** (String, Optional) A formula used to filter records. The formula will be evaluated for each record, and if the result is not `0`, `false`, `""`, `NaN`, `[]`, or `#Error!` the record will be included in the response. See the [formula documentation](https://support.airtable.com/hc/en-us/articles/203255215-Formula-Field-Reference) from Airtable.
 
 ### Read-only
 
@@ -49,5 +53,3 @@ Optional:
 - **created_time** (String)
 - **fields** (Map of String)
 - **id** (String)
-
-

--- a/internal/provider/data_source_table.go
+++ b/internal/provider/data_source_table.go
@@ -39,6 +39,17 @@ func dataSourceTable() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
+			"fields": {
+				Description: "Only data for fields whose names are in this list will be included in the result." +
+					"If you don't need every field, you can use this parameter to reduce the amount of data transferred.",
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filterByFormula": {
+				Description: "A formula used to filter records. If combined with the `view` parameter, " +
+					"only records in that new which satisfy the formula will be returned",
+				Optional: true,
+			},
 
 			"records": {
 				Description: "Records in the table / view.",

--- a/internal/provider/data_source_table.go
+++ b/internal/provider/data_source_table.go
@@ -48,6 +48,7 @@ func dataSourceTable() *schema.Resource {
 			"filterByFormula": {
 				Description: "A formula used to filter records. If combined with the `view` parameter, " +
 					"only records in that new which satisfy the formula will be returned",
+				Type:     schema.TypeList,
 				Optional: true,
 			},
 

--- a/internal/provider/data_source_table.go
+++ b/internal/provider/data_source_table.go
@@ -51,7 +51,7 @@ func dataSourceTable() *schema.Resource {
 			"filter_by_formula": {
 				Description: "A formula used to filter records. If combined with the `view` parameter, " +
 					"only records in that new which satisfy the formula will be returned",
-				Type:     schema.TypeList,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 

--- a/internal/provider/data_source_table.go
+++ b/internal/provider/data_source_table.go
@@ -87,9 +87,13 @@ func dataSourceTableRead(ctx context.Context, d *schema.ResourceData, meta inter
 	workspaceID := d.Get("workspace_id").(string)
 	table := d.Get("table").(string)
 	view := d.Get("view").(string)
+	fields := d.Get("fields").([]string)
+	filterByFormula := d.Get("filterByFormula").(string)
 
 	options := &sdk.ListRecordsOptions{
-		View: view,
+		View:            view,
+		Fields:          fields,
+		FilterByFormula: filterByFormula,
 	}
 
 	sdkRecords, err := c.client.ListRecords(workspaceID, table, options)

--- a/internal/provider/data_source_table.go
+++ b/internal/provider/data_source_table.go
@@ -42,7 +42,10 @@ func dataSourceTable() *schema.Resource {
 			"fields": {
 				Description: "Only data for fields whose names are in this list will be included in the result." +
 					"If you don't need every field, you can use this parameter to reduce the amount of data transferred.",
-				Type:     schema.TypeString,
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 				Optional: true,
 			},
 			"filter_by_formula": {

--- a/internal/provider/data_source_table.go
+++ b/internal/provider/data_source_table.go
@@ -45,7 +45,7 @@ func dataSourceTable() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"filterByFormula": {
+			"filter_by_formula": {
 				Description: "A formula used to filter records. If combined with the `view` parameter, " +
 					"only records in that new which satisfy the formula will be returned",
 				Type:     schema.TypeList,
@@ -87,13 +87,12 @@ func dataSourceTableRead(ctx context.Context, d *schema.ResourceData, meta inter
 	workspaceID := d.Get("workspace_id").(string)
 	table := d.Get("table").(string)
 	view := d.Get("view").(string)
-	fields := d.Get("fields").([]string)
-	filterByFormula := d.Get("filterByFormula").(string)
+	filter_by_formula := d.Get("filter_by_formula").(string)
 
 	options := &sdk.ListRecordsOptions{
 		View:            view,
 		Fields:          fields,
-		FilterByFormula: filterByFormula,
+		FilterByFormula: filter_by_formula,
 	}
 
 	sdkRecords, err := c.client.ListRecords(workspaceID, table, options)

--- a/internal/provider/data_source_table.go
+++ b/internal/provider/data_source_table.go
@@ -90,6 +90,7 @@ func dataSourceTableRead(ctx context.Context, d *schema.ResourceData, meta inter
 	workspaceID := d.Get("workspace_id").(string)
 	table := d.Get("table").(string)
 	view := d.Get("view").(string)
+	fields := d.Get("fields").([]interface{})
 	filter_by_formula := d.Get("filter_by_formula").(string)
 
 	options := &sdk.ListRecordsOptions{

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -66,7 +66,7 @@ type Record struct {
 
 type ListRecordsOptions struct {
 	View            string
-	Fields          []string
+	Fields          []interface{}
 	FilterByFormula string
 }
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -65,7 +65,9 @@ type Record struct {
 }
 
 type ListRecordsOptions struct {
-	View string
+	View            string
+	Fields          []string
+	FilterByFormula string
 }
 
 type listRecordsResponseRecord struct {
@@ -91,6 +93,16 @@ func (c *Client) ListRecords(workspaceID, table string, options *ListRecordsOpti
 
 	if options.View != "" {
 		queryParams.Add("view", options.View)
+	}
+
+	if options.Fields != nil {
+		for _, v := range options.Fields {
+			queryParams.Add("fields", v)
+		}
+	}
+
+	if options.FilterByFormula != "" {
+		queryParams.Add("filterByFormula", options.FilterByFormula)
 	}
 
 	records := []Record{}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -97,7 +97,8 @@ func (c *Client) ListRecords(workspaceID, table string, options *ListRecordsOpti
 
 	if options.Fields != nil {
 		for _, v := range options.Fields {
-			queryParams.Add("fields", v)
+			i := v.(string)
+			queryParams.Add("fields", i)
 		}
 	}
 


### PR DESCRIPTION
## What?
This PR will add the ability to select only defined fields and filter by an Airtable formula for the `airtable_table` data source.

## Why?
It will reduce the records (and fields) returned by the data source because currently everything is returned at once and it's a pain to deal with when you have a fairly large table.

## How?
This will add two more optional fields to the data source named `fields` (a list of strings) and `filter_by_formula` (string). Users can define a list of fields to only return them from the API and use an Airtable formula to further filter the records.

## Testing
Unfortunately only locally tested, as far as I can see the tests were made with a private Airtable base.

## More info
More tests should be implemented, especially for the new two parameters we've added to the data source. Can be easily tested locally though (with a private table of course)

Thanks!