### PR TITLE
Preserve complex fields

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2.1.1
         with:
-          go-version: '1.15'
+          go-version: '1.16'
       -
         name: Import GPG key
         id: import_gpg

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -69,9 +69,9 @@ type ListRecordsOptions struct {
 }
 
 type listRecordsResponseRecord struct {
-	ID             string            `json:"id"`
-	RawCreatedTime string            `json:"createdTime"`
-	Fields         map[string]string `json:"fields"`
+	ID             string                     `json:"id"`
+	RawCreatedTime string                     `json:"createdTime"`
+	RawFields      map[string]json.RawMessage `json:"fields"`
 }
 
 type listRecordsResponse struct {
@@ -111,8 +111,13 @@ func (c *Client) ListRecords(workspaceID, table string, options *ListRecordsOpti
 			if err != nil {
 				return nil, err
 			}
+			fields := make(map[string]string)
+			for key, field := range raw.RawFields {
+				val, _ := field.MarshalJSON()
+				fields[key] = string(val)
+			}
 			r := Record{
-				Fields:      raw.Fields,
+				Fields:      fields,
 				ID:          raw.ID,
 				CreatedTime: created,
 			}


### PR DESCRIPTION
Rather then discarding non-string fields we can simply return the API's JSON. This may not be ideal but it dose not alter any fields that worked before and allows:

    jsondecode(data.airtable_table.example.records[0].fields.Image).0.url

and multi-choice fields.